### PR TITLE
Update config to use MelonPreferences

### DIFF
--- a/AccuracyIndicator/AccuracyIndicator.csproj
+++ b/AccuracyIndicator/AccuracyIndicator.csproj
@@ -8,7 +8,6 @@
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
-        <ReferencePath>C:\Program Files (x86)\Steam\steamapps\common\Muse Dash</ReferencePath>
     </PropertyGroup>
 
     <ItemDefinitionGroup>
@@ -18,66 +17,66 @@
 
     <ItemGroup>
         <Reference Include="0Harmony">
-            <HintPath>$(ReferencePath)\MelonLoader\net6\0Harmony.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\net6\0Harmony.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="Assembly-CSharp">
-            <HintPath>$(ReferencePath)\MelonLoader\Il2CppAssemblies\Assembly-CSharp.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\Il2CppAssemblies\Assembly-CSharp.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="Il2CppInterop.Runtime">
-            <HintPath>$(ReferencePath)\MelonLoader\net6\Il2CppInterop.Runtime.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\net6\Il2CppInterop.Runtime.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="Il2Cppmscorlib">
-            <HintPath>$(ReferencePath)\MelonLoader\Il2CppAssemblies\Il2Cppmscorlib.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\Il2CppAssemblies\Il2Cppmscorlib.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="Il2CppSirenix.Serialization">
-            <HintPath>$(ReferencePath)\MelonLoader\Il2CppAssemblies\Il2CppSirenix.Serialization.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\Il2CppAssemblies\Il2CppSirenix.Serialization.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="MelonLoader">
-            <HintPath>$(ReferencePath)\MelonLoader\net6\MelonLoader.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\net6\MelonLoader.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="Tomlet">
-            <HintPath>$(ReferencePath)\MelonLoader\net6\Tomlet.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\net6\Tomlet.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="Unity.Addressables">
-            <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Muse Dash\MelonLoader\Il2CppAssemblies\Unity.Addressables.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\Il2CppAssemblies\Unity.Addressables.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="Unity.ResourceManager">
-            <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Muse Dash\MelonLoader\Il2CppAssemblies\Unity.ResourceManager.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\Il2CppAssemblies\Unity.ResourceManager.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(ReferencePath)\MelonLoader\Il2CppAssemblies\UnityEngine.CoreModule.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\Il2CppAssemblies\UnityEngine.CoreModule.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.InputLegacyModule">
-            <HintPath>$(ReferencePath)\MelonLoader\Il2CppAssemblies\UnityEngine.InputLegacyModule.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\Il2CppAssemblies\UnityEngine.InputLegacyModule.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.TextRenderingModule">
-            <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Muse Dash\MelonLoader\Il2CppAssemblies\UnityEngine.TextRenderingModule.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\Il2CppAssemblies\UnityEngine.TextRenderingModule.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.UI">
-            <HintPath>$(ReferencePath)\MelonLoader\Il2CppAssemblies\UnityEngine.UI.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\Il2CppAssemblies\UnityEngine.UI.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="UnityEngine.UIModule">
-            <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Muse Dash\MelonLoader\Il2CppAssemblies\UnityEngine.UIModule.dll</HintPath>
+            <HintPath>$(MD_DIRECTORY)\MelonLoader\Il2CppAssemblies\UnityEngine.UIModule.dll</HintPath>
             <Private>False</Private>
         </Reference>
     </ItemGroup>
 
     <Target Name="CopyMods" AfterTargets="Build">
-        <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="$(ReferencePath)\Mods"/>
-        <Message Text="Copied DLL -&gt; $(ReferencePath)\Mods\$(ProjectName).dll" Importance="High"/>
+        <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="$(MD_DIRECTORY)\Mods"/>
+        <Message Text="Copied DLL -&gt; $(MD_DIRECTORY)\Mods\$(ProjectName).dll" Importance="High"/>
     </Target>
 
 </Project>

--- a/AccuracyIndicator/Main.cs
+++ b/AccuracyIndicator/Main.cs
@@ -1,5 +1,4 @@
 using AccuracyIndicator.Indicator;
-using Tomlet;
 using Object = UnityEngine.Object;
 
 namespace AccuracyIndicator;
@@ -9,10 +8,11 @@ internal class Main : MelonMod
     internal static GameObject ResultIndicator { get; set; }
     internal static InGameIndicator GameIndicator { get; set; }
 
-    public override void OnInitializeMelon() => Save.Load();
-
-    public override void OnDeinitializeMelon() =>
-        File.WriteAllText(Path.Combine("UserData", "AccuracyIndicator.cfg"), TomletMain.TomlStringFrom(Save.Settings));
+    public override void OnInitializeMelon()
+    {
+        base.OnInitializeMelon();
+        Save.Load();
+    }   
 
     public override void OnSceneWasUnloaded(int buildIndex, string sceneName)
     {

--- a/AccuracyIndicator/MelonBuildInfo.cs
+++ b/AccuracyIndicator/MelonBuildInfo.cs
@@ -8,5 +8,5 @@ internal static class MelonBuildInfo
 
     internal const string Author = "Azn9 & lxy";
 
-    internal const string ModVersion = "2.0.2";
+    internal const string ModVersion = "2.1.0";
 }

--- a/AccuracyIndicator/Patch/VictoryFailPatch.cs
+++ b/AccuracyIndicator/Patch/VictoryFailPatch.cs
@@ -24,7 +24,7 @@ internal static class VictoryFailPatch
             Object.Destroy(GameIndicator);
             GameIndicator = null;
 
-            if (!Save.Settings.ShowMeanDelay)
+            if (!Save.ShowMeanDelay)
             {
                 return;
             }

--- a/AccuracyIndicator/Save.cs
+++ b/AccuracyIndicator/Save.cs
@@ -3,15 +3,16 @@ namespace AccuracyIndicator;
 
 internal static class Save
 {
-    private static MelonPreferences_Category prefsCategory; 
+    private static MelonPreferences_Category accuracyIndicatorCategory; 
     private static MelonPreferences_Entry<bool> showMeanDelay;
 
     internal static bool ShowMeanDelay => showMeanDelay.Value;
 
     public static void Load()
     {
-        prefsCategory = MelonPreferences.CreateCategory(MelonBuildInfo.Name);
-        showMeanDelay = prefsCategory.CreateEntry<bool>("ShowMeanDelay", true,
+        accuracyIndicatorCategory = MelonPreferences.CreateCategory(MelonBuildInfo.Name);
+        accuracyIndicatorCategory.SetFilePath("UserData/AccuracyIndicator.cfg");
+        showMeanDelay = accuracyIndicatorCategory.CreateEntry<bool>("ShowMeanDelay", true,
         "Victory screen mean delay", "Enables Mean Delay display in victory screen.");
     }
 }

--- a/AccuracyIndicator/Save.cs
+++ b/AccuracyIndicator/Save.cs
@@ -1,33 +1,17 @@
-using Tomlet;
-using Tomlet.Attributes;
-
+using MelonLoader;
 namespace AccuracyIndicator;
 
 internal static class Save
 {
-    internal static Data Settings { get; private set; } = new();
+    private static MelonPreferences_Category prefsCategory; 
+    private static MelonPreferences_Entry<bool> showMeanDelay;
+
+    internal static bool ShowMeanDelay => showMeanDelay.Value;
 
     public static void Load()
     {
-        if (!File.Exists(Path.Combine("UserData", "AccuracyIndicator.cfg")))
-        {
-            var defaultConfig = TomletMain.TomlStringFrom(new Data(true));
-            File.WriteAllText(Path.Combine("UserData", "AccuracyIndicator.cfg"), defaultConfig);
-        }
-
-        var data = File.ReadAllText(Path.Combine("UserData", "AccuracyIndicator.cfg"));
-        Settings = TomletMain.To<Data>(data);
+        prefsCategory = MelonPreferences.CreateCategory(MelonBuildInfo.Name);
+        showMeanDelay = prefsCategory.CreateEntry<bool>("ShowMeanDelay", true,
+        "Victory screen mean delay", "Enables Mean Delay display in victory screen.");
     }
-}
-
-public class Data
-{
-    [TomlPrecedingComment("Whether show Mean Delay in Victory screen")]
-    internal readonly bool ShowMeanDelay;
-
-    public Data()
-    {
-    }
-
-    internal Data(bool showMeanDelay) => ShowMeanDelay = showMeanDelay;
 }


### PR DESCRIPTION
 This update was focused on changing the config system to used the preferred MelonPreferences, and moved the only config entry into MelonPreferences.cfg.

The reason for this change was that I was under the mistaken assumption that a few other mods were recently updated to only support MelonLoader 0.7.0 which breaks the config system this mod used.

I have tested this version with MelonLoader 0.6.1 which is the officially supported version and there should be no issues.